### PR TITLE
fix backport manual modification to template

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -6,20 +6,20 @@ Run Emacs in docker containers!
 
 # Images
 
-| OS                                | Tag                      | Size (MB) | Inherits from | Contents                                                              |
-|-----------------------------------|--------------------------|-----------|---------------|-----------------------------------------------------------------------|
-| [Ubuntu](https://ubuntu.com)      | $version                 |       450 |               | Emacs, curl, gnupg & imagemagick                                      |
-| [Ubuntu](https://ubuntu.com)      | $version-dev             |      1400 | $version      | All build dependencies & source in `/opt/emacs`                       |
-| [Ubuntu](https://ubuntu.com)      | $version-ci              |       480 | $version      | [git](https://git-scm.com) & make                                     |
-| [Ubuntu](https://ubuntu.com)      | $version-ci-cask         |       520 | $version-ci   | [Cask](https://caskreadthedocs.io) & [Python](https://www.python.org) |
-| [Ubuntu](https://ubuntu.com)      | $version-ci-eldev        |       480 | $version-ci   | [eldev](https://github.com/doublep/eldev)                             |
-| [Ubuntu](https://ubuntu.com)      | $version-ci-keg          |       480 | $version-ci   | [keg](https://github.com/conao3/kegel)                                |
-| [Alpine](https://alpinelinux.org) | $version-alpine          |       220 |               | Emacs, curl, gnupg & imagemagick                                      |
-| [Alpine](https://alpinelinux.org) | $version-alpine-dev      |      1200 | $version      | All build dependencies & source in `/opt/emacs`                       |
-| [Alpine](https://alpinelinux.org) | $version-alpine-ci       |       240 | $version      | [git](https://git-scm.com) & make                                     |
-| [Alpine](https://alpinelinux.org) | $version-alpine-ci-cask  |       280 | $version-ci   | [Cask](https://caskreadthedocs.io) & [Python](https://www.python.org) |
-| [Alpine](https://alpinelinux.org) | $version-alpine-ci-eldev |       240 | $version-ci   | [eldev](https://github.com/doublep/eldev)                             |
-| [Alpine](https://alpinelinux.org) | $version-alpine-ci-keg   |       240 | $version-ci   | [keg](https://github.com/conao3/kegel)                                |
+| OS                                | Tag                      | Size (MB) | Inherits from      | Contents                                                              |
+|-----------------------------------|--------------------------|-----------|--------------------|-----------------------------------------------------------------------|
+| [Ubuntu](https://ubuntu.com)      | $version                 |       450 |                    | Emacs, curl, gnupg & imagemagick                                      |
+| [Ubuntu](https://ubuntu.com)      | $version-dev             |      1400 | $version           | All build dependencies & source in `/opt/emacs`                       |
+| [Ubuntu](https://ubuntu.com)      | $version-ci              |       480 | $version           | [git](https://git-scm.com) & make                                     |
+| [Ubuntu](https://ubuntu.com)      | $version-ci-cask         |       520 | $version-ci        | [Cask](https://caskreadthedocs.io) & [Python](https://www.python.org) |
+| [Ubuntu](https://ubuntu.com)      | $version-ci-eldev        |       480 | $version-ci        | [eldev](https://github.com/doublep/eldev)                             |
+| [Ubuntu](https://ubuntu.com)      | $version-ci-keg          |       480 | $version-ci        | [keg](https://github.com/conao3/kegel)                                |
+| [Alpine](https://alpinelinux.org) | $version-alpine          |       220 |                    | Emacs, curl, gnupg & imagemagick                                      |
+| [Alpine](https://alpinelinux.org) | $version-alpine-dev      |      1200 | $version-alpine    | All build dependencies & source in `/opt/emacs`                       |
+| [Alpine](https://alpinelinux.org) | $version-alpine-ci       |       240 | $version-alpine    | [git](https://git-scm.com) & make                                     |
+| [Alpine](https://alpinelinux.org) | $version-alpine-ci-cask  |       280 | $version-alpine-ci | [Cask](https://caskreadthedocs.io) & [Python](https://www.python.org) |
+| [Alpine](https://alpinelinux.org) | $version-alpine-ci-eldev |       240 | $version-alpine-ci | [eldev](https://github.com/doublep/eldev)                             |
+| [Alpine](https://alpinelinux.org) | $version-alpine-ci-keg   |       240 | $version-alpine-ci | [keg](https://github.com/conao3/kegel)                                |
 
 # Tags
 


### PR DESCRIPTION
Fix backport manual modification to template.
Silex/docker-emacs@85b524d is good but it doesn't modify template, the commit is disapeared if we run ./bin/generate.